### PR TITLE
Fix a path to the binary in DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update -y && apt-get install -y clang cmake ninja-build libtbb-dev
 ARG TARGET=Release
 COPY . src
 RUN cmake -D CMAKE_BUILD_TYPE=$TARGET -G Ninja -S src -B build
-RUN cmake --build build
+RUN cmake --install build
 
 FROM ubuntu:20.04 AS platform
 RUN apt-get update -y && apt-get install -y libtbb2
@@ -13,5 +13,5 @@ COPY --from=build /src/scripts/test .
 ENTRYPOINT ["./test"]
 
 FROM platform AS generator
-COPY --from=build /build/generator .
+COPY --from=build /build/install/bin/generator .
 ENTRYPOINT ["./generator"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ RUN apt-get update -y && apt-get install -y clang cmake ninja-build libtbb-dev
 ARG TARGET=Release
 COPY . src
 RUN cmake -D CMAKE_BUILD_TYPE=$TARGET -G Ninja -S src -B build
+RUN cmake --build build
 RUN cmake --install build
 
 FROM ubuntu:20.04 AS platform


### PR DESCRIPTION
Looks like publishing the artifact is failing in CI. This is probably
due to a bug introduced recently as a result of the binary file path
changing.

I've used the install option to give a predictable location to the
binary file.