### PR TITLE
Add a full path for the install prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,8 @@ list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake")
 # https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	set(CMAKE_INSTALL_PREFIX "install" CACHE PATH "Install path prefix." FORCE)
+	set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/install" CACHE PATH
+		"Install path prefix." FORCE)
 endif()
 
 # (step 5) Set the options for the build


### PR DESCRIPTION
As the install prefix did not have a full path, the installation could
have a varying location depending on where cmake was called from.

To make the results predictable during CI I've added a full path to the
project binary directory to the install prefix.